### PR TITLE
build(*): use esbuild instead of terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,7 +165,6 @@
         "stylelint": "^14.16.1",
         "stylelint-config-prettier": "^9.0.5",
         "stylelint-config-standard": "^29.0.0",
-        "terser-webpack-plugin": "^5.3.9",
         "thread-loader": "^4.0.2",
         "tree-node-cli": "^1.6.0",
         "typescript": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
     "stylelint": "^14.16.1",
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-standard": "^29.0.0",
-    "terser-webpack-plugin": "^5.3.9",
     "thread-loader": "^4.0.2",
     "tree-node-cli": "^1.6.0",
     "typescript": "^5.0.4",

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -2,7 +2,6 @@ const path = require('path')
 const { merge } = require('webpack-merge')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const TerserPlugin = require('terser-webpack-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 
 const glob = require('glob')
@@ -12,6 +11,7 @@ const CompressionWebpackPlugin = require('compression-webpack-plugin')
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 
 const HtmlMinimizerPlugin = require('html-minimizer-webpack-plugin')
+const { EsbuildPlugin } = require('esbuild-loader')
 
 const packageJson = require('../package.json')
 const common = require('./webpack.common.js')
@@ -51,23 +51,8 @@ const prodWebpackConfig = merge(common, {
     minimize: true,
     minimizer: [
       new CssMinimizerPlugin(),
-      new TerserPlugin({
-        parallel: true,
-        terserOptions: {
-          ecma: 6,
-          parse: {},
-          compress: {},
-          mangle: true,
-          module: false,
-          output: null,
-          format: null,
-          toplevel: false,
-          nameCache: null,
-          ie8: false,
-          keep_classnames: undefined,
-          keep_fnames: false,
-          safari10: false,
-        },
+      new EsbuildPlugin({
+        target: 'es2015',
       }),
       new HtmlMinimizerPlugin(),
     ],


### PR DESCRIPTION
我注意到项目里用到了 esbuild，我尝试把 terser 也替换为 esbuild。构建速度提升很明显。
在我的电脑上从 25022 ms 提升到了 9886 ms。

从产物大小来看，esbuild 生成的产物大小略大一点。比如 app.js 从 2.39 MB 变成了 2.44 MB。我认为这点变化是可以接受的。
这里有一个有用的仓库可以看到详细的 benchmark 比较：[minification-benchmarks](https://github.com/privatenumber/minification-benchmarks)

terser:
<img width="1044" alt="image" src="https://github.com/wkylin/pro-react-admin/assets/27916327/b7b6a197-ac65-449d-ac09-229d1c44ee1b">

esbuild:
<img width="1044" alt="image" src="https://github.com/wkylin/pro-react-admin/assets/27916327/97ad3a92-c385-422f-950b-a1e41dbe6e99">
